### PR TITLE
Replace short module names with FQCN

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -5,13 +5,13 @@
   pre_tasks:
     - name: pre-run | update package cache (arch)
       tags: always
-      pacman: update_cache=yes
+      community.general.pacman: update_cache=yes
       changed_when: False
       when: ansible_distribution == "Archlinux"
 
     - name: pre-run | update package cache (debian, etc)
       tags: always
-      apt: update_cache=yes
+      ansible.builtin.apt: update_cache=yes
       changed_when: False
       when: ansible_distribution in ["Debian", "Ubuntu"]
 
@@ -40,26 +40,26 @@
   tasks:
   - name: cleanup package cache (debian and ubuntu)
     tags: always
-    apt:
+    ansible.builtin.apt:
       autoclean: yes
     changed_when: false
     when: ansible_distribution in ["Debian", "Pop!_OS", "Ubuntu"]
 
   - name: autoremove orphan packages (debian and ubuntu)
     tags: always
-    apt:
+    ansible.builtin.apt:
       autoremove: yes
       purge: yes
     when: ansible_distribution in ["Debian", "Pop!_OS", "Ubuntu"]
 
   - name: send completion alert
-    include_tasks: playbooks/send_completion_alert.yml
+    ansible.builtin.include_tasks: playbooks/send_completion_alert.yml
     tags: always
     when:
       - task_failed is not defined
 
   - name: send failure alert
-    include_tasks: playbooks/send_failure_alert.yml
+    ansible.builtin.include_tasks: playbooks/send_failure_alert.yml
     tags: always
     when:
       - task_failed is defined

--- a/playbooks/send_failure_alert.yml
+++ b/playbooks/send_failure_alert.yml
@@ -25,6 +25,6 @@
 - name: ansible job failed, clear cache later on to trigger another provision run
   become: yes
   at:
-    command: "if ! pgrep -f ansible-pull >/dev/null; then rm -rf /home/simone/.ansible; fi"
+    ansible.builtin.command: "if ! pgrep -f ansible-pull >/dev/null; then rm -rf /home/simone/.ansible; fi"
     count: 60
     units: minutes

--- a/roles/base/handlers/main.yml
+++ b/roles/base/handlers/main.yml
@@ -1,22 +1,22 @@
 ---
 - name: apt_update
-  apt: update_cache=yes
+  ansible.builtin.apt: update_cache=yes
 
 - name: restart_sshd
-  service:
+  ansible.builtin.service:
     name: "{{ openssh_service }}"
     state: restarted
 
 - name: update_tmux_plugin_perms
-  file:
+  ansible.builtin.file:
     path: /home/jay/.tmux/plugins
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     recurse: true
 
 - name: update_vim_bundle_perms
-  file:
+  ansible.builtin.file:
     path: /home/jay/.vim/bundle
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     recurse: true

--- a/roles/base/tasks/ansible_setup.yml
+++ b/roles/base/tasks/ansible_setup.yml
@@ -1,12 +1,12 @@
 - name: ansible setup | ensure ansible is the latest version
   tags: ansible,ansible-setup
-  package:
+  ansible.builtin.package:
     name: ansible
     state: latest
 
 - name: ansible setup | install required packages
   tags: ansible,ansible-setup,packages
-  package:
+  ansible.builtin.package:
     name:
       - "{{ dconf_package }}"
       - "{{ python_psutil_package }}"
@@ -14,40 +14,40 @@
 # Note: For Arch, the requirement is met by a dependency of systemd, only necessary on Debian-based
 - name: ansible setup | install acl package
   tags: ansible,ansible-setup,packages
-  package:
+  ansible.builtin.package:
     name: acl
   when: ansible_distribution in ["Debian", "Pop!_OS", "Ubuntu"]
 
 - name: ansible setup | create ansible log file
   tags: ansible,ansible-setup
-  file:
+  ansible.builtin.file:
     path: /var/log/ansible.log
     owner: simone
-    group: ansible
+    ansible.builtin.group: ansible
     mode: 0664
     state: touch
   changed_when: False
 
 - name: ansible setup | add logrotate config for ansible log file
   tags: ansible-setup
-  copy:
+  ansible.builtin.copy:
     src: files/ansible_setup/logrotate
     dest: /etc/logrotate.d/ansible
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0644
 
 - name: ansible setup | remove default ansible directory (/etc/ansible) from host
   tags: ansible,ansible-setup
-  file:
+  ansible.builtin.file:
     path: /etc/ansible
     state: absent
 
 - name: ansible setup | generate provision script from template
   tags: ansible,ansible-setup,scripts
-  template:
+  ansible.builtin.template:
     src: provision.sh.j2
     dest: /usr/local/bin/provision
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0755

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -1,32 +1,32 @@
 # Load distro-specific variables
-- include_vars: "{{ ansible_distribution }}.yml"
+- ansible.builtin.include_vars: "{{ ansible_distribution }}.yml"
   tags: always
 
 - block:
   # Make sure users exist on the system
-  - import_tasks: users/jay.yml
-  - import_tasks: users/root.yml
-  - import_tasks: users/simone.yml
+  - ansible.builtin.import_tasks: users/jay.yml
+  - ansible.builtin.import_tasks: users/root.yml
+  - ansible.builtin.import_tasks: users/simone.yml
 
   # Set up the ansible environment
-  - import_tasks: ansible_setup.yml
+  - ansible.builtin.import_tasks: ansible_setup.yml
 
   # install software
-  - import_tasks: software/repositories.yml
-  - import_tasks: software/packages_development.yml
-  - import_tasks: software/packages_cleanup.yml
-  - import_tasks: software/packages_pip.yml
-  - import_tasks: software/packages_utilities.yml
+  - ansible.builtin.import_tasks: software/repositories.yml
+  - ansible.builtin.import_tasks: software/packages_development.yml
+  - ansible.builtin.import_tasks: software/packages_cleanup.yml
+  - ansible.builtin.import_tasks: software/packages_pip.yml
+  - ansible.builtin.import_tasks: software/packages_utilities.yml
 
   # Perform remaining tasks:
-  - import_tasks: system_setup/clock.yml
-  - import_tasks: system_setup/cron.yml
-  - import_tasks: system_setup/locale.yml
-  - import_tasks: system_setup/logging.yml
-  - import_tasks: system_setup/memory.yml
-  - import_tasks: system_setup/microcode.yml
-  - import_tasks: system_setup/openssh.yml
-  - import_tasks: system_setup/scripts.yml
+  - ansible.builtin.import_tasks: system_setup/clock.yml
+  - ansible.builtin.import_tasks: system_setup/cron.yml
+  - ansible.builtin.import_tasks: system_setup/locale.yml
+  - ansible.builtin.import_tasks: system_setup/logging.yml
+  - ansible.builtin.import_tasks: system_setup/memory.yml
+  - ansible.builtin.import_tasks: system_setup/microcode.yml
+  - ansible.builtin.import_tasks: system_setup/openssh.yml
+  - ansible.builtin.import_tasks: system_setup/scripts.yml
 
   rescue:
     - set_fact: task_failed=true

--- a/roles/base/tasks/software/packages_cleanup.yml
+++ b/roles/base/tasks/software/packages_cleanup.yml
@@ -1,6 +1,6 @@
 - name: system setup | package cleanup | remove unneeded packages (debian, ubuntu, etc)
   tags: cleanup,packages,system,settings
-  package:
+  ansible.builtin.package:
     state: absent
     name:
       - cowsay

--- a/roles/base/tasks/software/packages_development.yml
+++ b/roles/base/tasks/software/packages_development.yml
@@ -1,6 +1,6 @@
 - name: system setup | development packages | install packages
   tags: dev,development,packages,python,ruby
-  package:
+  ansible.builtin.package:
     name:
       - fabric
       - flake8

--- a/roles/base/tasks/software/packages_pip.yml
+++ b/roles/base/tasks/software/packages_pip.yml
@@ -1,7 +1,7 @@
 - name: system setup | pip packages | install bpytop
   tags: bpytop,packages,pip,python
   become_user: jay
-  pip:
+  ansible.builtin.pip:
     executable: /usr/bin/pip3
     state: latest
     name: bpytop

--- a/roles/base/tasks/software/packages_utilities.yml
+++ b/roles/base/tasks/software/packages_utilities.yml
@@ -1,6 +1,6 @@
 - name: system setup | utilities | install utility packages
   tags: packages,system,settings
-  package:
+  ansible.builtin.package:
     state: latest
     name:
       - at
@@ -32,7 +32,7 @@
 
 - name: system setup | utilities | install man-pages (arch)
   tags: packages,system,settings
-  pacman:
+  community.general.pacman:
     state: latest
     name:
       - man-db

--- a/roles/base/tasks/software/repositories.yml
+++ b/roles/base/tasks/software/repositories.yml
@@ -1,6 +1,6 @@
 - name: system setup | repositories | add ignored packages for archlinux hosts
   tags: packages,repositories
-  lineinfile:
+  ansible.builtin.lineinfile:
       dest: /etc/pacman.conf
       regexp: "^#?IgnorePkg"
       line: "IgnorePkg   = ansible linux linux-headers linux-lts linux-lts-headers"
@@ -8,7 +8,7 @@
 
 - name: system setup | repositories | add sources.list for debian hosts
   tags: non-free,repositories
-  copy:
+  ansible.builtin.copy:
     src: distribution_packages/debian_sources.list
     dest: /etc/apt/sources.list
     backup: yes
@@ -17,7 +17,7 @@
 
 - name: system setup | repositories | add debian-backports
   tags: backports,repositories
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: deb http://deb.debian.org/debian buster-backports main
     filename: debian-backports
   notify: apt_update
@@ -25,7 +25,7 @@
 
 - name: system setup | repositories | install package management tools (debian-based)
   tags: packages,system,settings
-  package:
+  ansible.builtin.package:
     name:
       - aptitude
       - software-properties-common

--- a/roles/base/tasks/system_setup/clock.yml
+++ b/roles/base/tasks/system_setup/clock.yml
@@ -1,6 +1,6 @@
 - name: system setup | clock | install systemd-timesyncd (ubuntu)
   tags: ntp,system setup
-  package:
+  ansible.builtin.package:
     name: systemd-timesyncd
     state: latest
   when: ansible_distribution in ["Pop!_OS", "Ubuntu"]
@@ -8,7 +8,7 @@
 # Currently systemd-timesyncd for debian is available only in buster-backports
 - name: system setup | clock | install systemd-timesyncd (debian)
   tags: ntp,system setup
-  apt:
+  ansible.builtin.apt:
     name: systemd-timesyncd
     default_release: buster-backports
     state: latest
@@ -16,12 +16,12 @@
 
 - name: system setup | clock | start and enable systemd-timesyncd
   tags: ntp,system settiings
-  service:
+  ansible.builtin.service:
     name: systemd-timesyncd
     state: started
     enabled: true
 
 - name: system setup | clock | set time zone
   tags: ntp,timezone,system setup
-  timezone:
+  community.general.timezone:
     name: "America/Detroit"

--- a/roles/base/tasks/system_setup/cron.yml
+++ b/roles/base/tasks/system_setup/cron.yml
@@ -1,13 +1,13 @@
 - name: system setup | cron | install cron package
   tags: packages,cron
-  package:
+  ansible.builtin.package:
     name:
       - "{{ cron_package }}"
     state: latest
 
 - name: system setup | cron | start and enable cronie daemon
   tags: cron
-  service:
+  ansible.builtin.service:
     name: cronie
     state: started
     enabled: true
@@ -15,17 +15,17 @@
 
 - name: system setup | cron | schedule automatic ansible provisioning
   tags: cron
-  cron:
+  ansible.builtin.cron:
     name: "ansible provision"
-    user: simone
+    ansible.builtin.user: simone
     hour: "{{ ansible_cron_hour | default('*') }}"
     minute: "{{ ansible_cron_minute | default('*/30') }}"
     job: "/usr/local/bin/provision > /dev/null"
 
 - name: system setup | cron | schedule ansible cleanup at boot
   tags: cron
-  cron:
+  ansible.builtin.cron:
     name: "ansible refresh at boot"
-    user: simone
+    ansible.builtin.user: simone
     special_time: reboot
     job: "/bin/rm -rf /home/simone/.ansible"

--- a/roles/base/tasks/system_setup/locale.yml
+++ b/roles/base/tasks/system_setup/locale.yml
@@ -1,24 +1,24 @@
 - name: system setup | locale | add en_US
   tags: locale,system,setup
-  locale_gen:
+  community.general.locale_gen:
     name: en_US.UTF-8
     state: present
 
 - name: system setup | locale | set locale to en_US
   tags: locale,system,setup
-  locale_gen:
+  community.general.locale_gen:
     name: en_US.UTF-8
     state: present
   register: locale
 
 - name: system setup | locale | set en_US as default locale
   tags: locale,system,setup
-  command: localectl set-locale LANG=en_US.UTF-8
+  ansible.builtin.command: localectl set-locale LANG=en_US.UTF-8
   when: locale.changed
 
 - name: system setup | locale | remove en_GB
   tags: locale,system,setup
-  locale_gen:
+  community.general.locale_gen:
     name: en_GB.UTF-8
     state: absent
   when: locale.changed

--- a/roles/base/tasks/system_setup/logging.yml
+++ b/roles/base/tasks/system_setup/logging.yml
@@ -1,13 +1,13 @@
 - name: system setup | logging | adjust retention period
   tags: systemd,journal,journald,sysctl,system setup
-  lineinfile:
+  ansible.builtin.lineinfile:
     dest: "/etc/systemd/journald.conf"
     regexp: "^#MaxFileSec="
     line: "MaxFileSec=5day"
   register: journald_config
 
 - name: system setup | logging | restart journald (config changed)
-  service:
+  ansible.builtin.service:
     name: systemd-journald
     state: restarted
   when: journald_config.changed

--- a/roles/base/tasks/system_setup/memory.yml
+++ b/roles/base/tasks/system_setup/memory.yml
@@ -1,6 +1,6 @@
 - name: system setup | memory | adjust current swappiness
   tags: swappiness,sysctl,system,setup
-  lineinfile:
+  ansible.builtin.lineinfile:
     dest: "/etc/sysctl.conf"
     create: yes
     regexp: "swappiness ="
@@ -9,18 +9,18 @@
 
 - name: system setup | memory | apply swappiness
   tags: swappiness,sysctl,system,setup
-  command: sysctl vm.swappiness={{ swappiness_value }}
+  ansible.builtin.command: sysctl vm.swappiness={{ swappiness_value }}
   when: swappiness.changed
 
 - name: system setup | memory | install earlyoom package
   tags: earlyoom,packages,system,setup
-  package:
+  ansible.builtin.package:
     name: earlyoom
     state: latest
 
 - name: system setup | memory | enable and start earlyoom
   tags: earlyoom,packages,system,setup
-  service:
+  ansible.builtin.service:
     name: earlyoom
     enabled: yes
     state: started

--- a/roles/base/tasks/system_setup/microcode.yml
+++ b/roles/base/tasks/system_setup/microcode.yml
@@ -1,6 +1,6 @@
 - name: system setup | microcode | install package for amd
   tags: amd,cpu,microcode,system setup
-  package:
+  ansible.builtin.package:
     name: "{{ amd_microcode_package }}"
     state: latest
   when:
@@ -9,7 +9,7 @@
 
 - name: system setup | microcode | install package for intel
   tags: cpu,intel,microcode,system setup
-  package:
+  ansible.builtin.package:
     name: "{{ intel_microcode_package }}"
     state: latest
   when:

--- a/roles/base/tasks/system_setup/openssh.yml
+++ b/roles/base/tasks/system_setup/openssh.yml
@@ -1,32 +1,32 @@
 - name: system setup | openssh | install or update daemon package
   tags: openssh,ssh,system,settings
-  package:
+  ansible.builtin.package:
     name: "{{ openssh_package }}"
     state: latest
   notify: restart_sshd
 
 - name: system setup | openssh | enable daemon
   tags: openssh,ssh,system,settings
-  service:
+  ansible.builtin.service:
     name: "{{ openssh_service }}"
     enabled: yes
     state: started
 
 - name: system setup | openssh | generate sshd_config file from template
   tags: openssh,ssh,system,settings
-  template:
+  ansible.builtin.template:
     src: sshd_config.j2
     dest: /etc/ssh/sshd_config
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0644
   notify: restart_sshd
 
 - name: system setup | openssh | copy issue.net
   tags: openssh,ssh,system,settings
-  copy:
+  ansible.builtin.copy:
     src: system_setup/openssh_issue.net
     dest: /etc/issue.net
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0644

--- a/roles/base/tasks/system_setup/scripts.yml
+++ b/roles/base/tasks/system_setup/scripts.yml
@@ -1,18 +1,18 @@
 - name: system setup | scripts | copy image_prep.sh script
   tags: scripts
-  copy:
+  ansible.builtin.copy:
     src: system_setup/image_prep.sh
     dest: /usr/local/bin/image_prep.sh
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0755
 
 - name: system setup | scripts | copy pi_cpu_temp.py script
   tags: scripts
-  copy:
+  ansible.builtin.copy:
     src: system_setup/pi_cpu_temp.py
     dest: /usr/local/bin/cpu_temp
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0755
   when: ansible_architecture == "aarch64"

--- a/roles/base/tasks/users/jay.yml
+++ b/roles/base/tasks/users/jay.yml
@@ -1,14 +1,14 @@
 - name: users | jay | create group
   tags: groups,jay,users
-  group:
+  ansible.builtin.group:
     name: jay
     state: present
 
 - name: users | jay | create user
   tags: jay,sudo,users
-  user:
+  ansible.builtin.user:
     name: jay
-    group: jay
+    ansible.builtin.group: jay
     groups: adm,ansible,{{ sudo_group }}
     state: present
     comment: "Jay LaCroix"
@@ -17,20 +17,20 @@
 
 - name: users | jay | jay | add sudoers file
   tags: jay,settings,simone,sudo,system,users
-  copy:
+  ansible.builtin.copy:
     src: users/sudoers_jay
     dest: /etc/sudoers.d/jay
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0440
 
 - name: users | jay | create .ssh directory
   tags: dotfiles,jay,ssh,users
-  file:
+  ansible.builtin.file:
     path: "{{ item.dir }}"
     state: directory
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     mode: 0700
   with_items:
     - { dir: '/home/jay/.ssh' }
@@ -38,18 +38,18 @@
 - name: users | jay | add public key
   tags: dotfiles,jay,ssh,ssh-keys,users
   authorized_key:
-    user: jay
+    ansible.builtin.user: jay
     key: "{{ item }}"
   with_file:
     - users/jay/ssh/jay_id_ed25519.pub
 
 - name: users | jay | create config directories
   tags: dotfiles,jay,tmux,users,vim,zsh
-  file:
+  ansible.builtin.file:
     path: /home/jay/{{ item.dir }}
     state: directory
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     mode: 0700
   with_items:
     - { dir: '.bash' }
@@ -68,31 +68,31 @@
 
 - name: users | jay | copy tmux config (server version)
   tags: dotfiles,users,jay,tmux,users,vim,zsh
-  copy:
+  ansible.builtin.copy:
     src: users/jay/tmux/tmux.conf.server
     dest: /home/jay/.tmux.conf
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     mode: 0600
   when: "'server' not in group_names"
 
 - name: users | jay | copy tmux config (workstation version)
   tags: dotfiles,users,jay,tmux,users,vim,zsh
-  copy:
+  ansible.builtin.copy:
     src: users/jay/tmux/tmux.conf.workstation
     dest: /home/jay/.tmux.conf
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     mode: 0600
   when: "'server' in group_names"
 
 - name: users | jay | copy dotfiles
   tags: dotfiles,users,jay,tmux,users,vim,zsh
-  copy:
+  ansible.builtin.copy:
     src: users/jay/{{ item.src }}
     dest: /home/jay/{{ item.dest }}
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     mode: 0600
   with_items:
     - { src: 'bash/bash_aliases', dest: '.bash/bash_aliases' }
@@ -110,7 +110,7 @@
 
 - name: users | jay | clone tmux-completion plugin repository
   tags: dotfiles,jay,users,tmux
-  git:
+  ansible.builtin.git:
     repo: https://github.com/srsudar/tmux-completion.git
     dest: /home/jay/.tmux/plugins/completion
     force: yes
@@ -118,7 +118,7 @@
 
 - name: users | jay | clone tmux-continuum plugin repository
   tags: dotfiles,jay,users,tmux
-  git:
+  ansible.builtin.git:
     repo: https://github.com/tmux-plugins/tmux-continuum
     dest: /home/jay/.tmux/plugins/continuum
     force: yes
@@ -126,7 +126,7 @@
 
 - name: users | jay | clone tmux-resurrect plugin repository
   tags: dotfiles,jay,users,tmux
-  git:
+  ansible.builtin.git:
     repo: https://github.com/tmux-plugins/tmux-resurrect
     dest: /home/jay/.tmux/plugins/resurrect
     force: yes
@@ -134,11 +134,11 @@
 
 - name: users | jay | copy individual zsh config files
   tags: dotfiles,jay,users,zsh
-  copy:
+  ansible.builtin.copy:
     src: users/jay/zsh/{{ item.src }}
     dest: /home/jay/.zsh/{{ item.src }}
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     mode: 0600
   with_items:
     - { src: 'aliases.zsh' }
@@ -155,11 +155,11 @@
 
 - name: users | jay | copy vim ftype files
   tags: dotfiles,jay,users,vim
-  copy:
+  ansible.builtin.copy:
     src: users/jay/vim/{{ item.src }}
     dest: /home/jay/.vim/ftplugin/{{ item.src }}
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     mode: 0600
   with_items:
     - { src: 'cmake.vim' }
@@ -173,11 +173,11 @@
 
 - name: users | jay | copy vim color files
   tags: dotfiles,jay,users,vim
-  copy:
+  ansible.builtin.copy:
     src: users/jay/vim/{{ item.src }}
     dest: /home/jay/.vim/colors/{{ item.src }}
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     mode: 0600
   with_items:
     - { src: 'bubblegum-256-dark.vim' }
@@ -188,11 +188,11 @@
 
 - name: users | jay | install pathogen
   tags: dotfiles,jay,users,vim
-  copy:
+  ansible.builtin.copy:
     src: users/jay/vim/{{ item.src }}
     dest: "{{ item.dest }}"
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     mode: 0700
   with_items:
     - { src: 'pathogen.vim', dest: '/home/jay/.vim/autoload/pathogen.vim' }
@@ -200,7 +200,7 @@
 - name: users | jay | checkout git repositories
   tags: git,users,jay
   become: yes
-  git:
+  ansible.builtin.git:
     repo: "{{ item.repo }}"
     dest: "{{ item.dest }}"
     force: yes

--- a/roles/base/tasks/users/root.yml
+++ b/roles/base/tasks/users/root.yml
@@ -1,14 +1,14 @@
 - name: users | root | ensure account is locked
-  user:
+  ansible.builtin.user:
     name: root
     password_lock: yes
 
 - name: users | root | create config directories
-  file:
+  ansible.builtin.file:
     path: /root/{{ item.dir }}
     state: directory
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0700
   with_items:
       - { dir: '.vim' }
@@ -16,11 +16,11 @@
   tags: dotfiles
 
 - name: users | root | copy dotfiles
-  copy:
+  ansible.builtin.copy:
     src: users/root/{{ item.src }}
     dest: /root/{{ item.dest}}
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0600
   with_items:
       - { src: 'bash/bashrc', dest: '.bashrc' }

--- a/roles/base/tasks/users/simone.yml
+++ b/roles/base/tasks/users/simone.yml
@@ -1,16 +1,16 @@
 - name: users | simone | add public key
   tags: dotfiles,simone,ssh,ssh-keys,users
   authorized_key:
-    user: simone
+    ansible.builtin.user: simone
     key: "{{ item }}"
   with_file:
     - users/simone/ssh/simone_id_ed25519.pub
 
 - name: users | simone | add sudoers file
   tags: settings,simone,sudo,system,users
-  copy:
+  ansible.builtin.copy:
     src: users/sudoers_simone
     dest: /etc/sudoers.d/simone
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0440

--- a/roles/server/handlers/main.yml
+++ b/roles/server/handlers/main.yml
@@ -1,18 +1,18 @@
 ---
 - name: restart_nrpe
   tags: nagios,nrpe
-  service:
+  ansible.builtin.service:
     name: "{{ nrpe_service }}"
     state: restarted
 
 - name: restart_qemu_agent
   tags: qemu,qemu-agent
-  service:
+  ansible.builtin.service:
     name: "{{ qemu_agent_service }}"
     state: restarted
 
 - name: restart_ufw
   tags: ufw
-  service:
+  ansible.builtin.service:
     name: ufw
     state: restarted

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -1,13 +1,13 @@
 # Load distro-specific variables
-- include_vars: "{{ ansible_distribution }}.yml"
+- ansible.builtin.include_vars: "{{ ansible_distribution }}.yml"
   tags: always
 
 - block:
-  - import_tasks: nrpe.yml
-  - import_tasks: ufw.yml
-  - import_tasks: qemu-agent.yml
+  - ansible.builtin.import_tasks: nrpe.yml
+  - ansible.builtin.import_tasks: ufw.yml
+  - ansible.builtin.import_tasks: qemu-agent.yml
 
-  - include_tasks: unattended_upgrades.yml
+  - ansible.builtin.include_tasks: unattended_upgrades.yml
     when:
       - ansible_distribution in ["Debian", "Pop!_OS", "Ubuntu"]
       - unattended_upgrades is defined

--- a/roles/server/tasks/nrpe.yml
+++ b/roles/server/tasks/nrpe.yml
@@ -1,6 +1,6 @@
 - name: nrpe | install nrpe package and plugins
   tags: nagios,nrpe
-  package:
+  ansible.builtin.package:
     state: latest
     name:
       - "{{ monitoring_plugins_package }}"
@@ -10,28 +10,28 @@
 
 - name: nrpe | generate nrpe.cfg file from template
   tags: openssh,ssh,system,settings
-  template:
+  ansible.builtin.template:
     src: nrpe.cfg.j2
     dest: "{{ nrpe_config_file_dest }}"
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0644
   notify: restart_nrpe
 
 - name: nrpe | enable and start nrpe service
   tags: nagios,nrpe
-  service:
+  ansible.builtin.service:
     name: "{{ nrpe_service }}"
     enabled: yes
     state: started
 
 - name: nrpe | copy additional plugins
   tags: nagios,nrpe
-  copy:
+  ansible.builtin.copy:
     src: nrpe/{{ item }}
     dest: "{{ monitoring_plugins_path }}/{{ item }}"
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0755
   with_items:
     - check_hddtemp
@@ -41,26 +41,26 @@
 
 - name: nrpe | create log file
   tags: ansible,ansible-setup
-  file:
+  ansible.builtin.file:
     path: /var/log/nrpe.log
     owner: "{{ nrpe_user }}"
-    group: "{{ nrpe_group }}"
+    ansible.builtin.group: "{{ nrpe_group }}"
     mode: 0664
     state: touch
   changed_when: False
 
 - name: nrpe | add logrotate config for nrpe log file
   tags: nrpe,server
-  copy:
+  ansible.builtin.copy:
     src: nrpe/logrotate
     dest: /etc/logrotate.d/nrpe
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0644
 
 - name: nrpe | clean up unneeded files (debian, etc)
   tags: nrpe,server
-  file:
+  ansible.builtin.file:
     path: /etc/nagios/{{ item }}
     state: absent
   with_items:

--- a/roles/server/tasks/qemu-agent.yml
+++ b/roles/server/tasks/qemu-agent.yml
@@ -1,6 +1,6 @@
 - name: qemu-agent | install package
   tags: packages,qemu,qemu-agent
-  package:
+  ansible.builtin.package:
     state: latest
     name:
       - qemu-guest-agent
@@ -10,7 +10,7 @@
 
 - name: qemu-agent | enable qemu agent daemon
   tags: nagios,nrpe
-  service:
+  ansible.builtin.service:
     name: "{{ qemu_agent_service }}"
     enabled: yes
     state: started

--- a/roles/server/tasks/ufw.yml
+++ b/roles/server/tasks/ufw.yml
@@ -1,6 +1,6 @@
 - name: ufw | install package
   tags: ufw
-  package:
+  ansible.builtin.package:
     state: latest
     name: ufw
   notify:

--- a/roles/server/tasks/unattended_upgrades.yml
+++ b/roles/server/tasks/unattended_upgrades.yml
@@ -1,6 +1,6 @@
 - name: unattended upgrades | install unattended-upgrades for debian-based hosts
   tags: packages,unattended,updates,upgrades
-  package:
+  ansible.builtin.package:
     state: latest
     name:
       - unattended-upgrades
@@ -8,30 +8,30 @@
 
 - name: unattended upgrades | copy 20auto-upgrades file for debian-based hosts
   tags: packages,unattended,updates,upgrades
-  copy:
+  ansible.builtin.copy:
     src: unattended-upgrades/20auto-upgrades
     dest: /etc/apt/apt.conf.d/20auto-upgrades
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0644
   when: ansible_distribution in ['Debian', 'Ubuntu']
 
 - name: unattended upgrades | copy 50unattended-upgrades file (debian)
   tags: debian,packages,unattended,updates,upgrades
-  copy:
+  ansible.builtin.copy:
     src: unattended-upgrades/50unattended-upgrades_debian
     dest: /etc/apt/apt.conf.d/50unattended-upgrades
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0644
   when: ansible_distribution == "Debian"
 
 - name: unattended upgrades | copy 50unattended-upgrades file (ubuntu)
   tags: packages,unattended,updates,ubuntu,upgrades
-  copy:
+  ansible.builtin.copy:
     src: unattended-upgrades/50unattended-upgrades_ubuntu
     dest: /etc/apt/apt.conf.d/50unattended-upgrades
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0644
   when: ansible_distribution == "Ubuntu"

--- a/roles/workstation/files/scripts/cht.sh
+++ b/roles/workstation/files/scripts/cht.sh
@@ -551,9 +551,9 @@ cmd_cd() {
 
 cmd_copy() {
   if [ -z "$DISPLAY" ]; then
-    echo copy: supported only in the Desktop version
+    echo ansible.builtin.copy: supported only in the Desktop version
   elif [ -z "$input" ]; then
-    echo copy: Make at least one query first.
+    echo ansible.builtin.copy: Make at least one query first.
   else
     curl -s "${CHTSH_URL}"/"$(get_query_options "$query"?T)" > "$TMP1"
     if [ "$is_macos" != yes ]; then
@@ -567,9 +567,9 @@ cmd_copy() {
 
 cmd_ccopy() {
   if [ -z "$DISPLAY" ]; then
-    echo copy: supported only in the Desktop version
+    echo ansible.builtin.copy: supported only in the Desktop version
   elif [ -z "$input" ]; then
-    echo copy: Make at least one query first.
+    echo ansible.builtin.copy: Make at least one query first.
   else
     curl -s "${CHTSH_URL}"/"$(get_query_options "$query"?TQ)" > "$TMP1"
     if [ "$is_macos" != yes ]; then

--- a/roles/workstation/handlers/main.yml
+++ b/roles/workstation/handlers/main.yml
@@ -1,13 +1,13 @@
 ---
 - name: restart_autofs
   tags: autofs,system,system setup
-  service:
+  ansible.builtin.service:
     name: autofs
     state: restarted
 
 - name: restart_earlyoom
   tags: earlyoom,system,system setup,tweaks
-  service:
+  ansible.builtin.service:
     name: earlyoom
     state: restarted
 
@@ -15,25 +15,25 @@
 # Note: Not using systemd module because it triggers a dbus error due to no session while user is not logged in
 - name: restart_syncthing
   tags: packages,syncthing
-  command: systemctl restart syncthing@jay
+  ansible.builtin.command: systemctl restart syncthing@jay
 
 - name: update_xdg
   tags: users,config,xdg
   become_user: jay
-  command: /usr/bin/xdg-user-dirs-update
+  ansible.builtin.command: /usr/bin/xdg-user-dirs-update
 
 # GNOME stuff
 - name: gnome_tracker_clean_cache
   tags: gnome,tracker
-  file:
+  ansible.builtin.file:
     path: /home/jay/.cache/tracker
     state: absent
 
 - name: gnome_tracker_clean_local_cache
   tags: gnome,tracker
-  file:
+  ansible.builtin.file:
     path: /home/jay/.local/share/tracker
     state: absent
 
 - name: enable_gnome_extensions
-  include_tasks: handlers/enable_gnome_extensions.yml
+  ansible.builtin.include_tasks: handlers/enable_gnome_extensions.yml

--- a/roles/workstation/tasks/desktop_environments/gnome/appearance.yml
+++ b/roles/workstation/tasks/desktop_environments/gnome/appearance.yml
@@ -1,63 +1,63 @@
 - name: gnome | appearance | copy wallpaper file
   tags: gnome,gnome-wallpaper
-  copy:
+  ansible.builtin.copy:
     src: gnome/wallpaper.png
     dest: /usr/share/backgrounds/jay-wallpaper.png
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0644
 
 - name: gnome | appearance | set wallpaper
   tags: gnome,gnome-wallpaper
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/background/picture-uri"
     value: "'file:///usr/share/backgrounds/jay-wallpaper.png'"
 
 - name: gnome | appearance | set wallpaper position
   tags: gnome,gnome-wallpaper
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/background/picture-options"
     value: "'zoom'"
 
 - name: gnome | appearance | copy lock screen background file
   tags: gnome,gnome-lockscreen
-  copy:
+  ansible.builtin.copy:
     src: files/gnome/lockscreen.jpg
     dest: /usr/share/backgrounds/jay-lockscreen.jpg
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0644
 
 - name: gnome | appearance | set lock screen background
   tags: gnome,gnome-lockscreen
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/screensaver/picture-uri"
     value: "'file:///usr/share/backgrounds/jay-lockscreen.jpg'"
 
 - name: gnome | appearance | set lock screen background position
   tags: gnome,gnome-lockscreen
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/screensaver/picture-options"
     value: "'zoom'"
 
 #- name: gnome | appearance | gnome | appearance | set icon theme
 #  become_user: jay
-#  dconf:
+#  community.general.dconf:
 #    key: "/org/gnome/desktop/interface/icon-theme"
 #    value: "'Moka-Minimal'"
 
 #- name: gnome | appearance | set GTK theme
 #  become_user: jay
-#  dconf:
+#  community.general.dconf:
 #    key: "/org/gnome/desktop/interface/gtk-theme"
 #    value: "'Shades-of-gray'"
 
 #- name: gnome | appearance | set shell theme
 #  become_user: jay
-#  dconf:
+#  community.general.dconf:
 #    key: "/org/gnome/shell/extensions/user-theme/name"
 #    value: "'Shades-of-gray'"

--- a/roles/workstation/tasks/desktop_environments/gnome/keybindings.yml
+++ b/roles/workstation/tasks/desktop_environments/gnome/keybindings.yml
@@ -1,7 +1,7 @@
 - name: gnome | keybindings | disable default browser key binding
   tags: gnome,keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
@@ -10,7 +10,7 @@
 - name: gnome | keybindings | disable default file manager binding
   tags: gnome,keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
@@ -19,7 +19,7 @@
 - name: gnome | keybindings | disable default email client binding
   tags: gnome,keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
@@ -28,7 +28,7 @@
 - name: gnome | keybindings | disable default terminal key binding
   tags: gnome,keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
@@ -37,14 +37,14 @@
 - name: gnome | keybindings | set custom-keybindings
   tags: gnome,keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings"
     value: "['/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom0/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom1/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom2/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom3/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom4/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom5/', '/org/gnome/settings-daemon/plugins/media-keys/custom-keybindings/custom6/']"
 
 - name: gnome | keybindings | set primary browser keybinding
   tags: gnome,keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value}}"
   with_items:
@@ -56,7 +56,7 @@
 - name: gnome | keybindings | set primary browser keybinding
   tags: gnome,keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value}}"
   with_items:
@@ -68,7 +68,7 @@
 - name: gnome | keybindings | set browser (alternate) keybinding
   tags: gnome,keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value}}"
   with_items:
@@ -79,7 +79,7 @@
 - name: gnome | keybindings | set file manager keybinding
   tags: gnome,keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value}}"
   with_items:
@@ -90,7 +90,7 @@
 - name: gnome | keybindings | set bpytop keybinding
   tags: gnome,keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value}}"
   with_items:
@@ -102,7 +102,7 @@
 - name: gnome | keybindings | set bpytop keybinding
   tags: gnome,keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value}}"
   with_items:
@@ -114,7 +114,7 @@
 - name: gnome | keybindings | set terminal keybinding
   tags: gnome,keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value}}"
   with_items:
@@ -126,7 +126,7 @@
 - name: gnome | keybindings | set terminal keybinding
   tags: gnome,keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value}}"
   with_items:
@@ -138,7 +138,7 @@
 - name: gnome | keybindings | set text editor keybinding
   tags: gnome,keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value}}"
   with_items:
@@ -150,7 +150,7 @@
 - name: gnome | keybindings | set text editor keybinding
   tags: gnome,keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value}}"
   with_items:
@@ -162,7 +162,7 @@
 - name: gnome | keybindings | set tmux keybinding
   tags: gnome,keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value}}"
   with_items:
@@ -174,7 +174,7 @@
 - name: gnome | keybindings | set tmux keybinding
   tags: gnome,keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value}}"
   with_items:
@@ -186,7 +186,7 @@
 # Uncommenting the below plays will restore the default GNOME shortcuts for these actions:
 #- name: gnome | keybindings | set keybindings for switching between workspaces
 #  become_user: jay
-#  dconf:
+#  community.general.dconf:
 #    key: "{{ item.key }}"
 #    value: "{{ item.value}}"
 #  with_items:
@@ -195,7 +195,7 @@
 
 #- name: gnome | keybindings | set key binding for moving windows to other workspaces
 #  become_user: jay
-#  dconf:
+#  community.general.dconf:
 #    key: "{{ item.key }}"
 #    value: "{{ item.value}}"
 #  with_items:
@@ -204,7 +204,7 @@
 
 #- name: gnome | keybindings | set maximize/minimize key bindings
 #  become_user: jay
-#  dconf:
+#  community.general.dconf:
 #    key: "/org/gnome/desktop/wm/keybindings/{{ item.key }}"
 #    value: "{{ item.value}}"
 #  with_items:

--- a/roles/workstation/tasks/desktop_environments/gnome/nautilus.yml
+++ b/roles/workstation/tasks/desktop_environments/gnome/nautilus.yml
@@ -1,41 +1,41 @@
 - name: gnome | nautilus | enable tree-view in nautilus
   tags: gnome,nautilus
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/nautilus/list-view/use-tree-view"
     value: "true"
 
 - name: gnome | nautilus | set list view in nautilus
   tags: gnome,nautilus
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/nautilus/preferences/default-folder-viewer"
     value: "'list-view'"
 
 - name: gnome | nautilus | configure single-click to open files
   tags: gnome,nautilus
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/nautilus/preferences/click-policy"
     value: "'single'"
 
 - name: gnome | nautilus | set executable text activation
   tags: gnome,nautilus
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/nautilus/preferences/executable-text-activation"
     value: "'launch'"
 
 - name: gnome | nautilus | enable option to permanently delete files
   tags: gnome,nautilus
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/nautilus/preferences/show-delete-permanently"
     value: "'true'"
 
 - name: gnome | nautilus | set directories to not be shown before files in nautilus
   tags: gnome,nautilus
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gtk/settings/file-chooser/sort-directories-first"
     value: "false"

--- a/roles/workstation/tasks/desktop_environments/gnome/packages.yml
+++ b/roles/workstation/tasks/desktop_environments/gnome/packages.yml
@@ -1,7 +1,7 @@
 # Note: Some of these packages are disabled, they depend on tracker which is currently being disabled
 - name: gnome | packages | install gnome packages
   tags: gnome,gnome-packages
-  package:
+  ansible.builtin.package:
     name:
       - eog
       - file-roller
@@ -28,7 +28,7 @@
 
 - name: gnome | packages | install flatpak support in gnome software
   tags: gnome,gnome-packages
-  package:
+  ansible.builtin.package:
     name:
     - gnome-software-plugin-flatpak
   when: ansible_distribution in ["Debian", "Ubuntu"]
@@ -37,14 +37,14 @@
 # This doesn't seem to be required in archlinux.
 - name: gnome | packages | install gnome support for network-manager for debian and ubuntu hosts
   tags: gnome,gnome-packages,packages
-  package:
+  ansible.builtin.package:
     name:
       - network-manager-openvpn-gnome
   when: ansible_distribution in ["Debian", "Pop!_OS", "Ubuntu"]
 
 - name: gnome | packages | enable and start gdm
   tags: autofs,system,system setup
-  service:
+  ansible.builtin.service:
     name: gdm
     enabled: true
     state: started

--- a/roles/workstation/tasks/desktop_environments/gnome/peripherals.yml
+++ b/roles/workstation/tasks/desktop_environments/gnome/peripherals.yml
@@ -1,97 +1,97 @@
 - name: gnome | peripherals | enable natural scrolling (mouse)
   tags: gnome,mouse,peripherals
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/peripherals/mouse/natural-scroll"
     value: "true"
 
 - name: gnome | peripherals | enable natural scrolling (touchpad)
   tags: gnome,mouse,peripherals
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/peripherals/touchpad/natural-scroll"
     value: "true"
 
 - name: gnome | peripherals | enable cursor acceleration (mouse)
   tags: gnome,mouse,peripherals
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/peripherals/mouse/accel-profile"
     value: "'adaptive'"
 
 - name: gnome | peripherals | increase cursor speed (mouse)
   tags: gnome,mouse,peripherals
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/peripherals/mouse/speed"
     value: "0.59999999999999998"
 
 - name: gnome | peripherals | increase cursor speed (touchpad)
   tags: gnome,mouse,peripherals
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/peripherals/touchpad/speed"
     value: "0.59999999999999998"
 
 - name: gnome | peripherals | set manual night-light schedule
   tags: gnome,peripherals,night-light
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/settings-daemon/plugins/color/night-light-schedule-automatic"
     value: "false"
 
 - name: gnome | peripherals | set manual night-light schedule start time
   tags: gnome,peripherals,night-light
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/settings-daemon/plugins/color/night-light-schedule-from"
     value: "23.0"
 
 - name: gnome | peripherals | set manual night-light schedule stop time
   tags: gnome,peripherals,night-light
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/settings-daemon/plugins/color/night-light-schedule-to"
     value: "7.4999999999999982"
 
 - name: gnome | peripherals | enable night-light
   tags: gnome,peripherals,night-light
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/settings-daemon/plugins/color/night-light-enabled"
     value: "true"
 
 - name: gnome | peripherals | set power button behavior
   tags: gnome,peripherals,power
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/settings-daemon/plugins/power/power-button-action"
     value: "'suspend'"
 
 - name: gnome | peripherals | enable automatic suspend while plugged in to ac
   tags: gnome,peripherals,power
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/settings-daemon/plugins/power/sleep-inactive-ac-type"
     value: "'suspend'"
 
 - name: gnome | peripherals | set timeout for automatic suspend while plugged in to ac
   tags: gnome,peripherals,power
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/settings-daemon/plugins/power/sleep-inactive-ac-timeout"
     value: "2700"
 
 - name: gnome | peripherals | enable automatic suspend while on battery
   tags: gnome,peripherals,power
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/settings-daemon/plugins/power/sleep-inactive-battery-type"
     value: "'suspend'"
 
 - name: gnome | peripherals | set timeout for automatic suspend while plugged in to ac
   tags: gnome,peripherals,power
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/settings-daemon/plugins/power/sleep-inactive-battery-timeout"
     value: "1500"

--- a/roles/workstation/tasks/desktop_environments/gnome/shell_settings.yml
+++ b/roles/workstation/tasks/desktop_environments/gnome/shell_settings.yml
@@ -1,7 +1,7 @@
 - name: gnome | shell settings | button-layout
   tags: gnome,gnome-shell
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/wm/preferences/button-layout"
     value: "':close'"
 
@@ -9,21 +9,21 @@
 - name: gnome | shell settings | enable-hot-corners
   tags: gnome,gnome-shell
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/shell/interface/enable-hot-corners"
     value: "false"
 
 - name: gnome | shell settings | event-sounds (disable)
   tags: gnome,audio,sounds,alerts
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/sound/event-sounds"
     value: "false"
 
 - name: gnome | shell settings | disable hidpi-daemon
   tags: gnome,gnome-shell,hidpi
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/com/system76/hidpi/enable"
     value: "false"
   when: ansible_distribution in ["Pop!_OS", "Ubuntu"]
@@ -32,7 +32,7 @@
 - name: gnome | shell settings | idle-delay
   tags: gnome,gnome-shell
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/session/idle-delay"
     value: "uint32 0"
 
@@ -40,7 +40,7 @@
 - name: gnome | shell settings | input-feedback-sounds (disable input sounds)
   tags: gnome,audio,sounds,alerts
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/sound/input-feedback-sounds"
     value: "false"
 
@@ -48,42 +48,42 @@
 - name: gnome | shell settings | lock-enabled
   tags: gnome,gnome-shell
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/screensaver/lock-enabled"
     value: "false"
 
 - name: gnome | shell settings | old-files-age
   tags: gnome,gnome-shell
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/privacy/old-files-age"
     value: "uint32 14"
 
 - name: gnome | shell settings | remove-old-temp-files
   tags: gnome,gnome-shell
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/privacy/remove-old-temp-files"
     value: "true"
 
 - name: gnome | shell settings | remove-old-trash-files
   tags: gnome,gnome-shell
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/privacy/remove-old-trash-files"
     value: "true"
 
 - name: gnome | shell settings | search-providers
   tags: gnome,search
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/search-providers/disabled"
     value: "['org.gnome.Nautilus.desktop', 'org.gnome.Calculator.desktop', 'org.gnome.seahorse.Application.desktop', 'org.gnome.Photos.desktop', 'org.gnome.Terminal.desktop', 'org.gnome.Documents.desktop', 'org.gnome.Contacts.desktop', 'org.gnome.Calendar.desktop']"
 
 - name: gnome | shell settings | show-battery-percentage
   tags: gnome,gnome-shell
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/interface/show-battery-percentage"
     value: "true"
 
@@ -91,14 +91,14 @@
 - name: gnome | shell settings | show-in-lock-screen
   tags: gnome,gnome-lockscreen
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/desktop/notifications/show-in-lock-screen"
     value: "false"
 
 - name: gnome | shell settings | tile-by-default
   tags: gnome,gnome-lockscreen
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/shell/extensions/pop-shell/tile-by-default"
     value: "true"
   when: ansible_distribution == "Pop!_OS"
@@ -106,13 +106,13 @@
 - name: gnome | shell settings | workspaces-only-on-primary
   tags: gnome,gnome-shell
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/shell/overrides/workspaces-only-on-primary"
     value: "true"
 
 - name: gnome | shell settings | set gnome-screenshot default save directory
   tags: gnome,gnome-shell
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/gnome-screenshot/auto-save-directory"
     value: "'/home/jay'"

--- a/roles/workstation/tasks/desktop_environments/gnome/terminal.yml
+++ b/roles/workstation/tasks/desktop_environments/gnome/terminal.yml
@@ -1,14 +1,14 @@
 - name: gnome | terminal | disable terminal menubar
   tags: gnome,gnome-terminal
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/terminal/legacy/default-show-menubar"
     value: "false"
 
 - name: gnome | terminal | set terminal configuration
   tags: gnome,gnome-terminal
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/gnome/terminal/legacy/profiles:/:b1dcc9dd-5262-4d8d-a863-c897e6d979b9/{{ item.key }}"
     value: "{{ item.value}}"
   with_items:

--- a/roles/workstation/tasks/desktop_environments/gnome/tracker.yml
+++ b/roles/workstation/tasks/desktop_environments/gnome/tracker.yml
@@ -2,7 +2,7 @@
 #- name: gnome | tracker | disable monitors
 #  tags: gnome,tracker
 #  become_user: jay
-#  dconf:
+#  community.general.dconf:
 #    key: "/org/freedesktop/tracker/miner/files/enable-monitors"
 #    value: "false"
 
@@ -10,7 +10,7 @@
 - name: gnome | tracker | disable indexing while running on battery
   tags: gnome,tracker
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/freedesktop/tracker/miner/files/index-on-battery"
     value: "false"
 
@@ -18,7 +18,7 @@
 - name: gnome | tracker | set ignored directories
   tags: gnome,tracker
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/freedesktop/tracker/miner/files/ignored-directories"
     value: "['po', 'CVS', 'core-dumps', '/home/jay/downloads', 'lost+found', '/mnt/freenas']"
   notify:

--- a/roles/workstation/tasks/desktop_environments/mate/appearance.yml
+++ b/roles/workstation/tasks/desktop_environments/mate/appearance.yml
@@ -6,26 +6,26 @@
 
 #- name: mate | appearance | set icon theme
 #  become_user: jay
-#  dconf:
+#  community.general.dconf:
 #    key: "/org/mate/desktop/interface/icon-theme"
 #    value: "'Ambiant-MATE'"
 
 #- name: mate | appearance | set gtk theme
 #  become_user: jay
-#  dconf:
+#  community.general.dconf:
 #    key: "/org/mate/desktop/interface/gtk-theme"
 #    value: "'Ambiant-MATE'"
 
 #- name: mate | appearance | set marco theme
 #  become_user: jay
-#  dconf:
+#  community.general.dconf:
 #    key: "/org/mate/marco/general/theme"
 #    value: "'Ambiant-MATE-Dark'"
 
 - name: mate | appearance | set wallpaper
   tags: mate,mate-wallpaper
   become_user: jay
-  dconf: key="/org/mate/desktop/background/{{ item.key }}" value={{ item.value}}
+  community.general.dconf: key="/org/mate/desktop/background/{{ item.key }}" value={{ item.value}}
   with_items:
     - { key: "color-shading-type", value: "'vertical-gradient'" }
     - { key: "picture-filename", value: "'/usr/share/backgrounds/cosmos/background-1.xml'" }

--- a/roles/workstation/tasks/desktop_environments/mate/caja.yml
+++ b/roles/workstation/tasks/desktop_environments/mate/caja.yml
@@ -2,7 +2,7 @@
 - name: mate | caja | show computer icon on desktop
   tags: caja,mate
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/mate/caja/desktop/computer-icon-visible"
     value: "true"
 
@@ -10,76 +10,76 @@
 - name: mate | caja | date-format
   tags: caja,mate
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/mate/caja/preferences/date-format"
     value: "'iso'"
 
 - name: mate | caja | default-folder-viewer (sets list view)
   tags: caja,mate
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/mate/caja/preferences/default-folder-viewer"
     value: "'list-view'"
 
 - name: mate | caja | default-visible-columns
   tags: caja,mate
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/mate/caja/list-view/default-visible-columns"
     value: "['name', 'size', 'date_modified']"
 
 - name: mate | caja | enable-delete
   tags: caja,mate
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/mate/caja/preferences/enable-delete"
     value: "true"
 
 - name: mate | caja | sort-directories-first
   tags: caja,mate
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/mate/caja/preferences/sort-directories-first"
     value: "false"
 
 - name: mate | caja | start-with-sidebar
   tags: caja,mate
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/mate/caja/window-state/start-with-sidebar"
     value: "false"
 
 - name: mate | caja | start-with-toolbar
   tags: caja,mate
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/mate/caja/window-state/start-with-toolbar"
     value: "false"
 
 - name: mate | caja | toolbar-icons-size
   tags: mate,mate-desktop
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/mate/desktop/interface/toolbar-icons-size"
     value: "'small-toolbar'"
 
 - name: mate | caja | toolbar-style
   tags: mate,mate-desktop
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/mate/desktop/interface/toolbar-style"
     value: "'icons'"
 
 - name: mate | caja | use-iec-units
   tags: caja,mate
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/mate/caja/preferences/use-iec-units"
     value: "true"
 
 - name: mate | caja | volumes-visible
   tags: caja,mate
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/mate/caja/desktop/volumes-visible"
     value: "true"

--- a/roles/workstation/tasks/desktop_environments/mate/keybindings.yml
+++ b/roles/workstation/tasks/desktop_environments/mate/keybindings.yml
@@ -1,7 +1,7 @@
 - name: mate | keybindings | set primary browser keybinding
   tags: mate,mate-keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
@@ -13,7 +13,7 @@
 - name: mate | keybindings | set primary browser keybinding
   tags: mate,mate-keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
@@ -25,7 +25,7 @@
 - name: mate | keybindings | set browser keybinding (alternate)
   tags: mate,mate-keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
@@ -36,7 +36,7 @@
 - name: mate | keybindings | set file manager keybinding
   tags: mate,mate-keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
@@ -47,7 +47,7 @@
 - name: mate | keybindings | set bpytop keybinding
   tags: mate,mate-keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
@@ -59,7 +59,7 @@
 - name: mate | keybindings | set bpytop keybinding
   tags: mate,mate-keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
@@ -71,7 +71,7 @@
 - name: mate | keybindings | set keepassxc keybinding
   tags: mate,mate-keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
@@ -82,7 +82,7 @@
 - name: gnome | set screenshot keybinding
   tags: gnome,keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
@@ -93,7 +93,7 @@
 - name: gnome | set screenshot (selection) keybinding
   tags: gnome,keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
@@ -104,7 +104,7 @@
 - name: mate | keybindings | set terminal keybinding
   tags: mate,mate-keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
@@ -116,7 +116,7 @@
 - name: mate | keybindings | set terminal keybinding
   tags: mate,mate-keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
@@ -128,7 +128,7 @@
 - name: mate | keybindings | set text editor keybinding
   tags: mate,mate-keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
@@ -140,7 +140,7 @@
 - name: mate | keybindings | set text editor keybinding
   tags: mate,mate-keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
@@ -152,7 +152,7 @@
 - name: mate | keybindings | set tmux keybinding
   tags: mate,mate-keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
@@ -164,7 +164,7 @@
 - name: mate | keybindings | set tmux keybinding
   tags: mate,mate-keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
@@ -176,7 +176,7 @@
 - name: mate | keybindings | set keybinding for switching between workspaces
   tags: mate,mate-keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
@@ -192,7 +192,7 @@
 - name: mate | keybindings | set keybinding for moving windows to other workspaces
   tags: mate,mate-keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value }}"
   with_items:
@@ -202,7 +202,7 @@
 - name: mate | keybindings | set tiling keybindings
   tags: mate,mate-keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
       key: "{{ item.key }}"
       value: "{{ item.value }}"
   with_items:
@@ -214,6 +214,6 @@
 - name: mate | keybindings | set keybinding for locking screen
   tags: mate,mate-keybindings
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/mate/settings-daemon/plugins/media-keys/screensaver"
     value: "'<Mod4>l'"

--- a/roles/workstation/tasks/desktop_environments/mate/packages.yml
+++ b/roles/workstation/tasks/desktop_environments/mate/packages.yml
@@ -1,6 +1,6 @@
 - name: mate | packages | install mate packages
   tags: mate,mate-packages
-  package:
+  ansible.builtin.package:
     name:
       - atril
       - caja
@@ -29,7 +29,7 @@
 
 - name: mate | packages | install ubuntu mate themes
   tags: mate,mate-packages
-  package:
+  ansible.builtin.package:
     name: ubuntu-mate-artwork
     state: latest
   when: ansible_distribution == "Ubuntu"

--- a/roles/workstation/tasks/desktop_environments/mate/peripherals.yml
+++ b/roles/workstation/tasks/desktop_environments/mate/peripherals.yml
@@ -1,7 +1,7 @@
 - name: mate | peripherals | configure touchpad
   tags: mouse,mate,mate-peripherals
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "{{ item.key }}"
     value: "{{ item.value}}"
   with_items:
@@ -11,20 +11,20 @@
 - name: mate | peripherals | disable suspend on ac
   tags: mate,mate-desktop,mate-power-manager
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/mate/power-manager/button-lid-ac"
     value: "'nothing'"
 
 - name: mate | peripherals | disable automatic suspend on ac
   tags: mate,mate-power-manager
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/mate/power-manager/sleep-display-ac"
     value: "0"
 
 - name: mate | peripherals | fix blueman's download directory path
   tags: blueman,mate
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/blueman/transfer/shared-path"
     value: "'/home/jay/downloads'"

--- a/roles/workstation/tasks/desktop_environments/mate/terminal.yml
+++ b/roles/workstation/tasks/desktop_environments/mate/terminal.yml
@@ -1,7 +1,7 @@
 - name: mate | terminal | set terminal configuration
   tags: mate,mate-terminal
   become_user: jay
-  dconf:
+  community.general.dconf:
     #    key: "/org/mate/terminal/profiles/b1dcc9dd-5262-4d8d-a863-c897e6d979b9/{{ item.key }}"
     key: "/org/mate/terminal/profiles/default/{{ item.key }}"
     value: "{{ item.value }}"

--- a/roles/workstation/tasks/desktop_environments/mate/workspace_settings.yml
+++ b/roles/workstation/tasks/desktop_environments/mate/workspace_settings.yml
@@ -1,14 +1,14 @@
 - name: mate | desktop settings | set number of workspaces
   tags: mate,mate-desktop,mate-workspaces
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/mate/marco/general/num-workspaces"
     value: "6"
 
 - name: mate | desktop settings | set workspace names
   tags: mate,mate-workspaces
   become_user: jay
-  dconf:
+  community.general.dconf:
     key: "/org/mate/marco/workspace-names/name-{{ item.number }}"
     value: "'{{ item.name }}'"
   with_items:

--- a/roles/workstation/tasks/main.yml
+++ b/roles/workstation/tasks/main.yml
@@ -1,102 +1,102 @@
 # Load distro-specific variables
-- include_vars: "{{ ansible_distribution }}.yml"
+- ansible.builtin.include_vars: "{{ ansible_distribution }}.yml"
   tags: always
 
 - block:
   ## User configs
-  - import_tasks: users/jay.yml
+  - ansible.builtin.import_tasks: users/jay.yml
 
 ## desktop environments
 
-  - include_tasks: desktop_environments/mate/appearance.yml
+  - ansible.builtin.include_tasks: desktop_environments/mate/appearance.yml
     when: mate is defined and mate == true
 
-  - include_tasks: desktop_environments/mate/caja.yml
+  - ansible.builtin.include_tasks: desktop_environments/mate/caja.yml
     when: mate is defined and mate == true
 
-  - include_tasks: desktop_environments/mate/keybindings.yml
+  - ansible.builtin.include_tasks: desktop_environments/mate/keybindings.yml
     when: mate is defined and mate == true
 
-  - include_tasks: desktop_environments/mate/packages.yml
+  - ansible.builtin.include_tasks: desktop_environments/mate/packages.yml
     when: mate is defined and mate == true
 
-  - include_tasks: desktop_environments/mate/peripherals.yml
+  - ansible.builtin.include_tasks: desktop_environments/mate/peripherals.yml
     when: mate is defined and mate == true
 
-  - include_tasks: desktop_environments/mate/terminal.yml
+  - ansible.builtin.include_tasks: desktop_environments/mate/terminal.yml
     when: mate is defined and mate == true
 
-  - include_tasks: desktop_environments/mate/workspace_settings.yml
+  - ansible.builtin.include_tasks: desktop_environments/mate/workspace_settings.yml
     when: mate is defined and mate == true
 
-  - include_tasks: desktop_environments/gnome/appearance.yml
+  - ansible.builtin.include_tasks: desktop_environments/gnome/appearance.yml
     when: gnome is defined and gnome == true
 
-  - include_tasks: desktop_environments/gnome/keybindings.yml
+  - ansible.builtin.include_tasks: desktop_environments/gnome/keybindings.yml
     when: gnome is defined and gnome == true
 
-  - include_tasks: desktop_environments/gnome/nautilus.yml
+  - ansible.builtin.include_tasks: desktop_environments/gnome/nautilus.yml
     when: gnome is defined and gnome == true
 
-  - include_tasks: desktop_environments/gnome/packages.yml
+  - ansible.builtin.include_tasks: desktop_environments/gnome/packages.yml
     when: gnome is defined and gnome == true
 
-  - include_tasks: desktop_environments/gnome/peripherals.yml
+  - ansible.builtin.include_tasks: desktop_environments/gnome/peripherals.yml
     when: gnome is defined and gnome == true
 
-  - include_tasks: desktop_environments/gnome/shell_settings.yml
+  - ansible.builtin.include_tasks: desktop_environments/gnome/shell_settings.yml
     when: gnome is defined and gnome == true
 
-  - include_tasks: desktop_environments/gnome/terminal.yml
+  - ansible.builtin.include_tasks: desktop_environments/gnome/terminal.yml
     when: gnome is defined and gnome == true
 
-  - include_tasks: desktop_environments/gnome/tracker.yml
+  - ansible.builtin.include_tasks: desktop_environments/gnome/tracker.yml
     when: gnome is defined and gnome == true
 
   ## system setup
-  - import_tasks: system_setup/autofs.yml
-  - import_tasks: system_setup/scripts.yml
-  - import_tasks: system_setup/tweaks.yml
+  - ansible.builtin.import_tasks: system_setup/autofs.yml
+  - ansible.builtin.import_tasks: system_setup/scripts.yml
+  - ansible.builtin.import_tasks: system_setup/tweaks.yml
 
   ## install software
-  - import_tasks: software/audacious.yml
-  - import_tasks: software/audacity.yml
-  - import_tasks: software/authy.yml
-  - import_tasks: software/bitwarden.yml
-  - import_tasks: software/caffeine.yml
-  - import_tasks: software/codecs.yml
-  - import_tasks: software/boto.yml
-  - import_tasks: software/chromium.yml
-  - import_tasks: software/darktable.yml
-  - import_tasks: software/firefox.yml
-  - import_tasks: software/foliate.yml
-  - import_tasks: software/google_chrome.yml
-  - import_tasks: software/glimpse.yml
-  - import_tasks: software/kdenlive.yml
-  - import_tasks: software/keepassxc.yml
-  - import_tasks: software/libreoffice.yml
-  - import_tasks: software/linode-cli.yml
-  - import_tasks: software/lutris.yml
-  - import_tasks: software/mattermost.yml
-  - import_tasks: software/minecraft.yml
-  - import_tasks: software/misc_games.yml
-  - import_tasks: software/misc_packages.yml
-  - import_tasks: software/openshot.yml
-  - import_tasks: software/packer.yml
-  - import_tasks: software/signal.yml
-  - import_tasks: software/solaar.yml
-  - import_tasks: software/spotify.yml
-  - import_tasks: software/steam.yml
-  - import_tasks: software/syncthing.yml
-  - import_tasks: software/terraform.yml
-  - import_tasks: software/thunderbird.yml
-  - import_tasks: software/todoist.yml
-  - import_tasks: software/ulauncher.yml
-  - import_tasks: software/vagrant.yml
-  - import_tasks: software/virtualbox.yml
-  - import_tasks: software/vivaldi.yml
-  - import_tasks: software/vlc.yml
-  - import_tasks: software/xonotic.yml
+  - ansible.builtin.import_tasks: software/audacious.yml
+  - ansible.builtin.import_tasks: software/audacity.yml
+  - ansible.builtin.import_tasks: software/authy.yml
+  - ansible.builtin.import_tasks: software/bitwarden.yml
+  - ansible.builtin.import_tasks: software/caffeine.yml
+  - ansible.builtin.import_tasks: software/codecs.yml
+  - ansible.builtin.import_tasks: software/boto.yml
+  - ansible.builtin.import_tasks: software/chromium.yml
+  - ansible.builtin.import_tasks: software/darktable.yml
+  - ansible.builtin.import_tasks: software/firefox.yml
+  - ansible.builtin.import_tasks: software/foliate.yml
+  - ansible.builtin.import_tasks: software/google_chrome.yml
+  - ansible.builtin.import_tasks: software/glimpse.yml
+  - ansible.builtin.import_tasks: software/kdenlive.yml
+  - ansible.builtin.import_tasks: software/keepassxc.yml
+  - ansible.builtin.import_tasks: software/libreoffice.yml
+  - ansible.builtin.import_tasks: software/linode-cli.yml
+  - ansible.builtin.import_tasks: software/lutris.yml
+  - ansible.builtin.import_tasks: software/mattermost.yml
+  - ansible.builtin.import_tasks: software/minecraft.yml
+  - ansible.builtin.import_tasks: software/misc_games.yml
+  - ansible.builtin.import_tasks: software/misc_packages.yml
+  - ansible.builtin.import_tasks: software/openshot.yml
+  - ansible.builtin.import_tasks: software/packer.yml
+  - ansible.builtin.import_tasks: software/signal.yml
+  - ansible.builtin.import_tasks: software/solaar.yml
+  - ansible.builtin.import_tasks: software/spotify.yml
+  - ansible.builtin.import_tasks: software/steam.yml
+  - ansible.builtin.import_tasks: software/syncthing.yml
+  - ansible.builtin.import_tasks: software/terraform.yml
+  - ansible.builtin.import_tasks: software/thunderbird.yml
+  - ansible.builtin.import_tasks: software/todoist.yml
+  - ansible.builtin.import_tasks: software/ulauncher.yml
+  - ansible.builtin.import_tasks: software/vagrant.yml
+  - ansible.builtin.import_tasks: software/virtualbox.yml
+  - ansible.builtin.import_tasks: software/vivaldi.yml
+  - ansible.builtin.import_tasks: software/vlc.yml
+  - ansible.builtin.import_tasks: software/xonotic.yml
 
   rescue:
     - set_fact: task_failed=true

--- a/roles/workstation/tasks/software/audacious.yml
+++ b/roles/workstation/tasks/software/audacious.yml
@@ -1,7 +1,7 @@
 - name: software | audacious | install package
   tags: packages,flatpak,audacious,workstation-packages
   become_user: jay
-  flatpak:
+  community.general.flatpak:
     name: org.atheme.audacious
     method: user
     state: present

--- a/roles/workstation/tasks/software/audacity.yml
+++ b/roles/workstation/tasks/software/audacity.yml
@@ -1,7 +1,7 @@
 - name: software | audacity | install package
   tags: packages,flatpak,audacity,workstation-packages
   become_user: jay
-  flatpak:
+  community.general.flatpak:
     name: org.audacityteam.Audacity
     method: user
     state: present

--- a/roles/workstation/tasks/software/authy.yml
+++ b/roles/workstation/tasks/software/authy.yml
@@ -1,7 +1,7 @@
 # note: snap packages not automated in arch yet, snapd is not available in repo
 - name: software | authy | install package
   tags: packages,authy,snap,workstation-packages
-  snap:
+  community.general.snap:
     name:  authy
     channel: latest/edge
     state: present
@@ -12,11 +12,11 @@
 
 - name: software | authy | enable autostart
   tags: packages,authy,snap,workstation-packages
-  file:
+  ansible.builtin.file:
     src: /var/lib/snapd/desktop/applications/authy_authy.desktop
     dest: /home/jay/.config/autostart/authy.desktop
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     state: link
   when:
     - ansible_distribution != "Archlinux"

--- a/roles/workstation/tasks/software/bitwarden.yml
+++ b/roles/workstation/tasks/software/bitwarden.yml
@@ -1,7 +1,7 @@
 - name: software | bitwarden | install package
   tags: bitwarden,packages,flatpak,workstation-packages
   become_user: jay
-  flatpak:
+  community.general.flatpak:
     name: flathub com.bitwarden.desktop
     method: user
     state: present

--- a/roles/workstation/tasks/software/boto.yml
+++ b/roles/workstation/tasks/software/boto.yml
@@ -1,7 +1,7 @@
 - name: software | boto | install package
   tags: boto,packages,pip,python
   become_user: jay
-  pip:
+  ansible.builtin.pip:
     executable: /usr/bin/pip3
     state: latest
     name: boto

--- a/roles/workstation/tasks/software/caffeine.yml
+++ b/roles/workstation/tasks/software/caffeine.yml
@@ -1,6 +1,6 @@
 # Arch isn't packaging caffeine for some stupid reason.
 - name: software | install caffeine
   tags: packages,workstation-packages,caffeine
-  package:
+  ansible.builtin.package:
     name: caffeine
   when: ansible_distribution != "Archlinux"

--- a/roles/workstation/tasks/software/chromium.yml
+++ b/roles/workstation/tasks/software/chromium.yml
@@ -2,7 +2,7 @@
 
 - name: software | chromium | install snap package
   tags: packages,chromium,snap,workstation-packages
-  snap:
+  community.general.snap:
     name:  chromium
     state: present
   when:
@@ -12,7 +12,7 @@
 
 - name: software | chromium | install distro package (arch)
   tags: packages,chromium,snap,workstation-packages
-  package:
+  ansible.builtin.package:
     name:  chromium
     state: latest
   when:

--- a/roles/workstation/tasks/software/codecs.yml
+++ b/roles/workstation/tasks/software/codecs.yml
@@ -1,6 +1,6 @@
 - name: software | install multimedia codecs
   tags: packages,system,system-packages,workstation-packages
-  package:
+  ansible.builtin.package:
     name:
       - "{{ gstreamer_libav_package }}"
       - "{{ gstreamer_plugins_bad_package }}"

--- a/roles/workstation/tasks/software/darktable.yml
+++ b/roles/workstation/tasks/software/darktable.yml
@@ -1,7 +1,7 @@
 - name: software | darktable | install package
   tags: packages,flatpak,darktable,workstation-packages
   become_user: jay
-  flatpak:
+  community.general.flatpak:
     name: org.darktable.Darktable
     method: user
     state: present

--- a/roles/workstation/tasks/software/firefox.yml
+++ b/roles/workstation/tasks/software/firefox.yml
@@ -1,7 +1,7 @@
 - name: software | firefox | install package
   tags: packages,firefox,flatpak,workstation-packages
   become_user: jay
-  flatpak:
+  community.general.flatpak:
     name: org.mozilla.firefox
     method: user
     state: present

--- a/roles/workstation/tasks/software/foliate.yml
+++ b/roles/workstation/tasks/software/foliate.yml
@@ -1,7 +1,7 @@
 - name: software | foliate | install package
   tags: packages,flatpak,foliate,workstation-packages
   become_user: jay
-  flatpak:
+  community.general.flatpak:
     name: com.github.johnfactotum.Foliate
     method: user
     state: present

--- a/roles/workstation/tasks/software/glimpse.yml
+++ b/roles/workstation/tasks/software/glimpse.yml
@@ -1,7 +1,7 @@
 - name: software | glimpse | install package
   tags: packages,flatpak,glimpse,workstation-packages
   become_user: jay
-  flatpak:
+  community.general.flatpak:
     name: org.glimpse_editor.Glimpse
     method: user
     state: present

--- a/roles/workstation/tasks/software/google_chrome.yml
+++ b/roles/workstation/tasks/software/google_chrome.yml
@@ -1,22 +1,22 @@
 - name: software | google-chrome | add repository key
-  apt_key:
+  ansible.builtin.apt_key:
     url: https://dl-ssl.google.com/linux/linux_signing_key.pub
   when: ansible_distribution in ["Debian", "Pop!_OS", "Ubuntu"]
 
 - name: software | google-chrome | add repository
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main"
     filename: google-chrome
   register: chrome_repo
   when: ansible_distribution in ["Debian", "Pop!_OS", "Ubuntu"]
 
 - name: software | google-chrome | update sources (repo added or changed)
-  apt:
+  ansible.builtin.apt:
     update_cache: yes
   changed_when: False
   when: chrome_repo.changed
 
 - name: software | google-chrome | install package
-  apt:
+  ansible.builtin.apt:
     name: google-chrome-stable
   when: ansible_distribution in ["Debian", "Pop!_OS", "Ubuntu"]

--- a/roles/workstation/tasks/software/kdenlive.yml
+++ b/roles/workstation/tasks/software/kdenlive.yml
@@ -1,16 +1,16 @@
 - name: software | kdenlive | copy launcher
   tags: apps,appimage,software,kdenlive
-  copy:
+  ansible.builtin.copy:
     src: users/jay/kdenlive.desktop
     dest: /home/jay/.local/share/applications/kdenlive.desktop
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     mode: 0700
 
 - name: software | kdenlive | install package
-  get_url:
+  ansible.builtin.get_url:
     url: https://download.kde.org/stable/kdenlive/20.08/linux/kdenlive-20.08.2-x86_64.appimage
     dest: /home/jay/bin/kdenlive.app
     mode: '0700'
     owner: jay
-    group: jay
+    ansible.builtin.group: jay

--- a/roles/workstation/tasks/software/keepassxc.yml
+++ b/roles/workstation/tasks/software/keepassxc.yml
@@ -1,37 +1,37 @@
 - name: software | keepassxc | install package
   tags: packages,firefox,flatpak,workstation-packages
   become_user: jay
-  flatpak:
+  community.general.flatpak:
     name: org.keepassxc.KeePassXC
     method: user
     state: present
 
 - name: software | keepassxc | enable autostart
   tags: packages,keepassxc,flatpak,workstation-packages
-  file:
+  ansible.builtin.file:
     src: /home/jay/.local/share/flatpak/exports/share/applications/org.keepassxc.KeePassXC.desktop
     dest: /home/jay/.config/autostart/org.keepassxc.KeePassXC.desktop
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     state: link
 
 - name: software | keepassxc | create keepassxc install directory
   tags: packages,keepassxc,flatpak,workstation-packages
-  file:
+  ansible.builtin.file:
     path: /home/jay/.config/keepassxc
     state: directory
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     mode: 0700
   register: keepassxc_config_dir
   when: keepassxc is defined and keepassxc == true
 
 - name: software | keepassxc | add initial keepassxc config
   tags: packages,keepassxc,flatpak,workstation-packages
-  copy:
+  ansible.builtin.copy:
     src: users/jay/keepassxc.ini
     dest: /home/jay/.config/keepassxc/keepassxc.ini
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     mode: 0600
   when: keepassxc is defined and keepassxc == true

--- a/roles/workstation/tasks/software/libreoffice.yml
+++ b/roles/workstation/tasks/software/libreoffice.yml
@@ -1,7 +1,7 @@
 - name: software | libreoffice | install package
   tags: packages,flatpak,libreoffice,workstation-packages
   become_user: jay
-  flatpak:
+  community.general.flatpak:
     name: org.libreoffice.LibreOffice
     method: user
     state: present

--- a/roles/workstation/tasks/software/linode-cli.yml
+++ b/roles/workstation/tasks/software/linode-cli.yml
@@ -1,7 +1,7 @@
 - name: software | linode-cli | install package
   tags: packages,linode,pip,python
   become_user: jay
-  pip:
+  ansible.builtin.pip:
     executable: /usr/bin/pip3
     state: latest
     name: linode-cli

--- a/roles/workstation/tasks/software/lutris.yml
+++ b/roles/workstation/tasks/software/lutris.yml
@@ -1,7 +1,7 @@
 # As of 2020-06-18, lutris is not available on debian
 - name: software | lutris | install ppa
   tags: gaming,lutris
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: 'ppa:lutris-team/lutris'
     state: present
   when:
@@ -11,7 +11,7 @@
 
 - name: software | lutris | install package
   tags: gaming,lutris
-  package:
+  ansible.builtin.package:
     state: latest
     name: lutris
   when:

--- a/roles/workstation/tasks/software/mattermost.yml
+++ b/roles/workstation/tasks/software/mattermost.yml
@@ -1,7 +1,7 @@
 - name: software | mattermost | install package
   tags: packages,flatpak,mattermost,workstation-packages
   become_user: jay
-  flatpak:
+  community.general.flatpak:
     name: com.mattermost.Desktop
     method: user
     state: present
@@ -9,10 +9,10 @@
 
 - name: software | mattermost | enable autostart
   tags: packages,flatpak,mattermost,workstation-packages
-  file:
+  ansible.builtin.file:
     src: /home/jay/.local/share/flatpak/exports/share/applications/com.mattermost.Desktop.desktop
     dest: /home/jay/.config/autostart/com.mattermost.Desktop.desktop
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     state: link
   when: mattermost is defined and mattermost == true

--- a/roles/workstation/tasks/software/minecraft.yml
+++ b/roles/workstation/tasks/software/minecraft.yml
@@ -1,7 +1,7 @@
 - name: software | minecraft | install package
   tags: packages,flatpak,games,minecraft,workstation-packages
   become_user: jay
-  flatpak:
+  community.general.flatpak:
     name: com.mojang.Minecraft
     method: user
     state: present

--- a/roles/workstation/tasks/software/misc_games.yml
+++ b/roles/workstation/tasks/software/misc_games.yml
@@ -1,6 +1,6 @@
 - name: software | install misc game packages
   tags: gaming
-  package:
+  ansible.builtin.package:
     name:
       - chromium-bsu
       - extremetuxracer

--- a/roles/workstation/tasks/software/misc_packages.yml
+++ b/roles/workstation/tasks/software/misc_packages.yml
@@ -1,6 +1,6 @@
 - name: software | install workstation distribution packages
   tags: packages,workstation-packages
-  package:
+  ansible.builtin.package:
     name:
       - acpid
       - alsa-utils
@@ -45,7 +45,7 @@
 
 - name: software | install system packages specific to debian and ubuntu
   tags: packages,system,system-packages,workstation-packages
-  package:
+  ansible.builtin.package:
     name:
       - synaptic
       - vim-gtk3
@@ -53,7 +53,7 @@
 
 - name: software | remove unneeded workstation packages on debian and ubuntu hosts
   tags: cleanup,packages,workstation-packages
-  package:
+  ansible.builtin.package:
     state: absent
     name:
       - firefox*

--- a/roles/workstation/tasks/software/openshot.yml
+++ b/roles/workstation/tasks/software/openshot.yml
@@ -1,7 +1,7 @@
 - name: software | openshot | install package
-  get_url:
+  ansible.builtin.get_url:
     url: https://github.com/OpenShot/openshot-qt/releases/download/v2.5.1/OpenShot-v2.5.1-x86_64.AppImage
     dest: /home/jay/bin/openshot.app
     mode: '0700'
     owner: jay
-    group: jay
+    ansible.builtin.group: jay

--- a/roles/workstation/tasks/software/packer.yml
+++ b/roles/workstation/tasks/software/packer.yml
@@ -1,9 +1,9 @@
 - name: software | packer | install binary
-  unarchive:
+  ansible.builtin.unarchive:
     src: https://releases.hashicorp.com/packer/{{ packer_version }}/packer_{{ packer_version }}_linux_amd64.zip
     dest: /usr/local/bin
     remote_src: yes
     mode: 0755
     owner: root
-    group: root
+    ansible.builtin.group: root
   when: packer is defined and packer == true

--- a/roles/workstation/tasks/software/signal.yml
+++ b/roles/workstation/tasks/software/signal.yml
@@ -1,7 +1,7 @@
 - name: software | signal | install package
   tags: packages,flatpak,signal,workstation-packages
   become_user: jay
-  flatpak:
+  community.general.flatpak:
     name: org.signal.Signal
     method: user
     state: present
@@ -9,10 +9,10 @@
 
 - name: software | signal | enable autostart
   tags: packages,flatpak,signal,workstation-packages
-  file:
+  ansible.builtin.file:
     src: /home/jay/.local/share/flatpak/exports/share/applications/org.signal.Signal.desktop
     dest: /home/jay/.config/autostart/org.signal.Signal.desktop
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     state: link
   when: signal is defined and signal == true

--- a/roles/workstation/tasks/software/solaar.yml
+++ b/roles/workstation/tasks/software/solaar.yml
@@ -1,10 +1,10 @@
 - name: software | install workstation distribution packages
   tags: packages,workstation-packages
-  package:
+  ansible.builtin.package:
     name: solaar
     state: latest
 
 - name: software | make sure solaar doesn't autostart
-  file:
+  ansible.builtin.file:
     path: /etc/xdg/autostart/solaar.desktop
     state: absent

--- a/roles/workstation/tasks/software/spotify.yml
+++ b/roles/workstation/tasks/software/spotify.yml
@@ -1,7 +1,7 @@
 - name: software | spotify | install package
   tags: packages,flatpak,spotify,workstation-packages
   become_user: jay
-  flatpak:
+  community.general.flatpak:
     name: com.spotify.Client
     method: user
     state: present

--- a/roles/workstation/tasks/software/steam.yml
+++ b/roles/workstation/tasks/software/steam.yml
@@ -1,6 +1,6 @@
 # For some reason Manjaro is detected as Archlinux
 - name: software | steam | check if distribution is manjaro
-  stat:
+  ansible.builtin.stat:
     path: /usr/bin/manjaro-hello
   register: manjaro
   when:
@@ -10,7 +10,7 @@
 
 - name: software | steam | steam | enable multilib (arch)
   tags: steam,steam,multilib
-  blockinfile:
+  ansible.builtin.blockinfile:
     state: present
     backup: yes
     path: /etc/pacman.conf
@@ -27,7 +27,7 @@
 
 - name: software | steam | update cache (multilib added) (arch)
   tags: steam,steam,multilib
-  pacman: update_cache=yes
+  community.general.pacman: update_cache=yes
   when:
     - multilib.changed
     - ansible_distribution == "Archlinux"
@@ -36,7 +36,7 @@
 # Note: Not required in Pop OS, apparently
 - name: steam | add multiarch (debian, ubuntu)
   tags: steam,steam,multiarch
-  lineinfile:
+  ansible.builtin.lineinfile:
       dest: /var/lib/dpkg/arch
       regexp: "^i386"
       line: "i386"
@@ -49,7 +49,7 @@
 # For Debian and Ubuntu, set up acceptance of steam license before continuing
 - name: software | steam | accept license
   tags: gaming,steam
-  debconf:
+  ansible.builtin.debconf:
     name: "steam"
     question: "steam/question"
     value: "I AGREE"
@@ -61,7 +61,7 @@
 
 - name: software | steam | install package
   tags: steam,steam
-  package:
+  ansible.builtin.package:
     state: latest
     name: "{{ steam_package }}"
   when:
@@ -70,7 +70,7 @@
 
 - name: software | steam | install steam-devices package (debian, ubuntu, etc)
   tags: steam,steam
-  package:
+  ansible.builtin.package:
     state: latest
     name: steam-devices
   when:
@@ -80,7 +80,7 @@
 
 - name: install vulkan drivers (debian, ubuntu, etc)
   tags: drivers,steam
-  package:
+  ansible.builtin.package:
     state: latest
     name: mesa-vulkan-drivers
   when:

--- a/roles/workstation/tasks/software/syncthing.yml
+++ b/roles/workstation/tasks/software/syncthing.yml
@@ -1,11 +1,11 @@
 # add syncthing-controlled directories
 - name: software | syncthing | create directories
   tags: syncthing
-  file:
+  ansible.builtin.file:
     path: /home/jay/{{ item.dir }}
     state: directory
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     mode: 0700
   with_items:
     - { dir: bin }
@@ -18,11 +18,11 @@
 
 - name: software | syncthing | copy .stignore file to synced directories
   tags: syncthing
-  copy:
+  ansible.builtin.copy:
     src: users/jay/stignore
     dest: /home/jay/{{ item.dir }}/.stignore
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     mode: 0600
   with_items:
     - { dir: bin }
@@ -36,7 +36,7 @@
 # syncthing repository for debian and ubuntu
 - name: software | syncthing | install apt key
   tags: syncthing
-  apt_key:
+  ansible.builtin.apt_key:
     url: https://syncthing.net/release-key.txt
     state: present
   when:
@@ -46,7 +46,7 @@
 
 - name: software | syncthing | install repository
   tags: syncthing
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: deb https://apt.syncthing.net/ syncthing stable
     state: present
     filename: syncthing
@@ -57,7 +57,7 @@
 
 - name: software | syncthing | install syncthing packages
   tags: syncthing
-  package:
+  ansible.builtin.package:
     name:
       - syncthing
       #- syncthing-gtk
@@ -69,11 +69,11 @@
 
 #- name: software | syncthing | add .desktop file for autostarting syncthing-gtk
 #  tags: syncthing
-#  copy:
+#  ansible.builtin.copy:
 #    src: users/jay/syncthing-gtk.desktop
 #    dest: /home/jay/.config/autostart/syncthing-gtk.desktop
 #    owner: jay
-#    group: jay
+#    ansible.builtin.group: jay
 #    mode: 0600
 #  when:
 #    - syncthing is defined
@@ -81,11 +81,11 @@
 
 #- name: software | syncthing | ensure syncthing-gtk config folder exists
 #  tags: syncthing
-#  file:
+#  ansible.builtin.file:
 #    path: /home/jay/.config/syncthing-gtk
 #    state: directory
 #    owner: jay
-#    group: jay
+#    ansible.builtin.group: jay
 #    mode: 0700
 #  when:
 #   - syncthing is defined
@@ -93,11 +93,11 @@
 
 #- name: software | syncthing | add initial configuration file for syncthing-gtk
 #  tags: syncthing
-#  copy:
+#  ansible.builtin.copy:
 #    src: users/jay/syncthing_config.json
 #    dest: /home/jay/.config/syncthing-gtk/config.json
 #    owner: jay
-#    group: jay
+#    ansible.builtin.group: jay
 #    mode: 0600
 #  when:
 #    - syncthing is defined
@@ -107,7 +107,7 @@
 # Note: Not using systemd module because it triggers a dbus error due to no session while user is not logged in
 - name: software | syncthing | start and enable syncthing
   tags: syncthing
-  command: "{{ item }}"
+  ansible.builtin.command: "{{ item }}"
   with_items:
     - systemctl enable syncthing@jay
     - systemctl restart syncthing@jay
@@ -125,10 +125,10 @@
 - name: software | syncthing | config.xml - disable browser
   tags: syncthing
   become_user: jay
-  replace:
+  ansible.builtin.replace:
     path: /home/jay/.config/syncthing/config.xml
     regexp: "<startBrowser>true</startBrowser>"
-    replace: "<startBrowser>false</startBrowser>"
+    ansible.builtin.replace: "<startBrowser>false</startBrowser>"
   notify: restart_syncthing
   when:
     - syncthing is defined
@@ -137,10 +137,10 @@
 - name: software | syncthing | config.xml - set ui theme
   tags: syncthing
   become_user: jay
-  replace:
+  ansible.builtin.replace:
     path: /home/jay/.config/syncthing/config.xml
     regexp: "<theme>default</theme>"
-    replace: "<theme>dark</theme>"
+    ansible.builtin.replace: "<theme>dark</theme>"
   notify: restart_syncthing
   when:
     - syncthing is defined
@@ -148,6 +148,6 @@
 
 - name: software | syncthing | remove default sync directory (~/Sync) from host
   tags: syncthing
-  file:
+  ansible.builtin.file:
     path: /home/jay/Sync
     state: absent

--- a/roles/workstation/tasks/software/terraform.yml
+++ b/roles/workstation/tasks/software/terraform.yml
@@ -1,9 +1,9 @@
 - name: software | terraform | install binary
-  unarchive:
+  ansible.builtin.unarchive:
     src: https://releases.hashicorp.com/terraform/{{ terraform_version }}/terraform_{{ terraform_version }}_linux_amd64.zip
     dest: /usr/local/bin
     remote_src: yes
     mode: 0755
     owner: root
-    group: root
+    ansible.builtin.group: root
   when: terraform is defined and terraform == true

--- a/roles/workstation/tasks/software/thunderbird.yml
+++ b/roles/workstation/tasks/software/thunderbird.yml
@@ -1,7 +1,7 @@
 - name: software | thunderbird | install package
   tags: packages,flatpak,thunderbird,workstation-packages
   become_user: jay
-  flatpak:
+  community.general.flatpak:
     name: org.mozilla.thunderbird
     method: user
     state: present
@@ -9,10 +9,10 @@
 
 - name: software | thunderbird | enable autostart
   tags: packages,flatpak,thunderbird,workstation-packages
-  file:
+  ansible.builtin.file:
     src: /home/jay/.local/share/flatpak/exports/share/applications/org.mozilla.Thunderbird.desktop
     dest: /home/jay/.config/autostart/org.mozilla.Thunderbird.desktop
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     state: link
   when: thunderbird is defined and thunderbird == true

--- a/roles/workstation/tasks/software/todoist.yml
+++ b/roles/workstation/tasks/software/todoist.yml
@@ -1,7 +1,7 @@
 # note: snap packages not automated in arch yet, snapd is not available in repo
 - name: software | todoist | install package
   tags: packages,snap,todoist,workstation-packages
-  snap:
+  community.general.snap:
     name:  todoist
     state: present
   when:
@@ -11,11 +11,11 @@
 
 - name: software | todoist | enable autostart
   tags: packages,todoist,snap,workstation-packages
-  file:
+  ansible.builtin.file:
     src: /var/lib/snapd/desktop/applications/todoist_todoist.desktop
     dest: /home/jay/.config/autostart/todoist_todoist.desktop
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     state: link
   when:
     - ansible_distribution != "Archlinux"

--- a/roles/workstation/tasks/software/ulauncher.yml
+++ b/roles/workstation/tasks/software/ulauncher.yml
@@ -1,6 +1,6 @@
 - name: software | ulauncher | install ppa
   tags: ulauncher
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: 'ppa:agornostal/ulauncher'
     state: present
   when:
@@ -10,7 +10,7 @@
 
 - name: software | ulauncher | install package
   tags: ulauncher
-  apt:
+  ansible.builtin.apt:
     name: ulauncher
     state: latest
   when:
@@ -20,11 +20,11 @@
 
 - name: software | ulauncher | enable autostart
   tags: ulauncher
-  copy:
+  ansible.builtin.copy:
     src: users/jay/ulauncher.desktop
     dest: /home/jay/.config/autostart/ulauncher.desktop
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     mode: 0600
   when:
     - ansible_distribution in ["Pop!_OS", "Ubuntu"]

--- a/roles/workstation/tasks/software/vagrant.yml
+++ b/roles/workstation/tasks/software/vagrant.yml
@@ -1,11 +1,11 @@
 - name: software | vagrant | install binary
-  unarchive:
+  ansible.builtin.unarchive:
     src: https://releases.hashicorp.com/vagrant/{{ vagrant_version }}/vagrant_{{ vagrant_version }}_linux_amd64.zip
     dest: /usr/local/bin
     remote_src: yes
     mode: 0755
     owner: root
-    group: root
+    ansible.builtin.group: root
   when:
     - vagrant is defined
     - vagrant == true

--- a/roles/workstation/tasks/software/virtualbox.yml
+++ b/roles/workstation/tasks/software/virtualbox.yml
@@ -3,7 +3,7 @@
 
 - name: software | virtualbox | install apt key (debian)
   tags: virtualbox,repositories,virtualbox
-  apt_key:
+  ansible.builtin.apt_key:
     url: https://www.virtualbox.org/download/oracle_vbox_2016.asc
     state: present
   when:
@@ -13,7 +13,7 @@
 
 - name: software | virtualbox | install repository (debian)
   tags: virtualbox,repositories,virtualbox
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: deb https://download.virtualbox.org/virtualbox/debian buster contrib
     state: present
     filename: virtualbox
@@ -25,7 +25,7 @@
 
 - name: software | virtualbox | install package
   tags: virtualbox
-  package:
+  ansible.builtin.package:
     name: "{{ virtualbox_package }}"
   when:
     - virtualbox is defined

--- a/roles/workstation/tasks/software/vivaldi.yml
+++ b/roles/workstation/tasks/software/vivaldi.yml
@@ -1,6 +1,6 @@
 - name: software | vivaldi | add repository key
   tags: packages,vivaldi
-  apt_key:
+  ansible.builtin.apt_key:
     url: https://repo.vivaldi.com/stable/linux_signing_key.pub
     state: present
   when:
@@ -9,13 +9,13 @@
     - vivaldi == true
 
 - name: software | vivaldi | check if repository exists
-  stat:
+  ansible.builtin.stat:
     path: /etc/apt/sources.list.d/vivaldi.list
   register: vivaldi_repo_file
 
 - name: software | vivaldi | add repository
   tags: packages,vivaldi
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: "deb https://repo.vivaldi.com/stable/deb/ stable main"
     state: present
     filename: vivaldi
@@ -27,7 +27,7 @@
 
 - name: software | vivaldi | install package
   tags: packages,vivaldi
-  apt:
+  ansible.builtin.apt:
     name: vivaldi-stable
     state: latest
   when:

--- a/roles/workstation/tasks/software/vlc.yml
+++ b/roles/workstation/tasks/software/vlc.yml
@@ -1,7 +1,7 @@
 - name: software | vlc | install package
   tags: packages,flatpak,vlc,workstation-packages
   become_user: jay
-  flatpak:
+  community.general.flatpak:
     name: org.videolan.VLC
     method: user
     state: present

--- a/roles/workstation/tasks/software/xonotic.yml
+++ b/roles/workstation/tasks/software/xonotic.yml
@@ -1,7 +1,7 @@
 - name: software | xonotic | install package
   tags: packages,flatpak,games,xonotic,workstation-packages
   become_user: jay
-  flatpak:
+  community.general.flatpak:
     name: org.xonotic.Xonotic
     method: user
     state: present

--- a/roles/workstation/tasks/system_setup/autofs.yml
+++ b/roles/workstation/tasks/system_setup/autofs.yml
@@ -1,6 +1,6 @@
 - name: system setup | autofs | install package
   tags: autofs
-  package:
+  ansible.builtin.package:
     name: autofs
   when:
     - autofs is defined
@@ -8,7 +8,7 @@
 
 - name: autofs | start and enable daemon
   tags: autofs
-  service:
+  ansible.builtin.service:
     name: autofs
     state: started
     enabled: true
@@ -18,11 +18,11 @@
 
 - name: system setup | autofs | copy auto.master config file
   tags: autofs,dotfiles,dotfiles-jay
-  copy:
+  ansible.builtin.copy:
     src: autofs/auto.master
     dest: "{{ autofs_master_config }}"
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0644
   when:
     - autofs is defined
@@ -31,11 +31,11 @@
 
 - name: system setup | autofs | copy auto.nfs config file
   tags: autofs,dotfiles,dotfiles-jay
-  copy:
+  ansible.builtin.copy:
     src: autofs/auto.nfs
     dest: "{{ autofs_nfs_config }}"
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0644
   when:
     - autofs is defined

--- a/roles/workstation/tasks/system_setup/scripts.yml
+++ b/roles/workstation/tasks/system_setup/scripts.yml
@@ -1,17 +1,17 @@
 - name: system setup | scripts | copy cht.sh script
   tags: distro-setup
-  copy:
+  ansible.builtin.copy:
     src: scripts/cht.sh
     dest: /usr/local/bin/cht.sh
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0755
 
 - name: system setup | scripts | copy pishrink.sh script
   tags: distro-setup
-  copy:
+  ansible.builtin.copy:
     src: scripts/pishrink.sh
     dest: /usr/local/bin/pishrink.sh
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0755

--- a/roles/workstation/tasks/system_setup/tweaks.yml
+++ b/roles/workstation/tasks/system_setup/tweaks.yml
@@ -1,13 +1,13 @@
 # set up flatpak support
 - name: system setup | tweaks | add flatpak support
-  package:
+  ansible.builtin.package:
     name: flatpak
     state: present
 
 - name: system setup | tweaks | flatpak | add flathub remote
   tags: packages,flatpak,workstation-packages
   become_user: jay
-  flatpak_remote:
+  community.general.flatpak_remote:
     name: flathub
     flatpakrepo_url: https://flathub.org/repo/flathub.flatpakrepo
     method: user
@@ -17,7 +17,7 @@
 # set up snap support
 # Note: Not available in Arch currently as of 2020-09-15
 - name: system setup | tweaks | install snapd
-  package:
+  ansible.builtin.package:
     name: snapd
     state: latest
   when: ansible_distribution != "Archlinux"
@@ -25,7 +25,7 @@
 # Ensure core snap is installed
 - name: system setup | tweaks | install/update core snap
   tags: packages,snap,todoist,workstation-packages
-  snap:
+  community.general.snap:
     name:  core
     state: present
   when: ansible_distribution != "Archlinux"
@@ -34,13 +34,13 @@
 # distro-specific tasks for arch
 - name: system setup | tweaks | install xorg (archlinux)
   tags: distro,distro-setup,packages,system,system-packages,workstation-packages
-  package:
+  ansible.builtin.package:
     name: xorg-server
   when: ansible_distribution == "Archlinux"
 
 - name: system setup | tweaks | install nvidia gpu packages (arch)
   tags: distro,distro-setup,packages,nvidia,system,system-packages,workstation-packages
-  package:
+  ansible.builtin.package:
     name:
       - nvidia
       - nvidia-lts
@@ -52,7 +52,7 @@
 
 - name: system setup | tweaks | install vbox gpu packages (arch)
   tags: distro,distro-setup,packages,system,system-packages,vbox,workstation-packages
-  package:
+  ansible.builtin.package:
     name:
       - virtualbox-guest-utils
       - xf86-video-vmware
@@ -64,7 +64,7 @@
 
 - name: system setup | tweaks | add exceptions for earlyoom
   tags: system,system-setup,tweaks
-  lineinfile:
+  ansible.builtin.lineinfile:
       dest: /etc/default/earlyoom
       regexp: '^EARLYOOM_ARGS="-r 60"'
       line: "EARLYOOM_ARGS=\"-m 5 -r 60 --avoid '(^|/)(init|Xorg|ssh|kdenlive*)$'\""
@@ -74,7 +74,7 @@
 # distro-specific tasks for ubuntu
 - name: system setup | tweaks | disable apport in config on ubuntu-based hosts
   tags: distro,distro-setup,apport,ubuntu
-  lineinfile:
+  ansible.builtin.lineinfile:
     dest: /etc/default/apport
     regexp: "enabled="
     line: "enabled=0"
@@ -83,7 +83,7 @@
 
 - name: system setup | tweaks | disable and stop apport service on ubuntu-based hosts
   tags: distro,distro-setup,apport,ubuntu
-  service:
+  ansible.builtin.service:
     name: apport
     enabled: no
     state: stopped

--- a/roles/workstation/tasks/users/jay.yml
+++ b/roles/workstation/tasks/users/jay.yml
@@ -1,5 +1,5 @@
 - name: users | jay | remove preinstalled clutter from home directory
-  file:
+  ansible.builtin.file:
     path: /home/jay/{{ item }}
     state: absent
   with_items:
@@ -15,11 +15,11 @@
 
 - name: users | jay | create personal config directories
   tags: dotfiles,dotfiles-jay
-  file:
+  ansible.builtin.file:
     path: /home/jay/{{ item.dir }}
     state: directory
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     mode: 0700
   with_items:
     - { dir: .config }
@@ -39,21 +39,21 @@
 
 - name: users | jay | copy user-dirs.dirs
   tags: dotfiles,dotfiles-jay
-  copy:
+  ansible.builtin.copy:
     src: users/jay/user-dirs.dirs
     dest: /home/jay/.config/user-dirs.dirs
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     mode: 0600
   notify: update_xdg
 
 - name: users | jay | copy personal config files
   tags: dotfiles,dotfiles-jay
-  copy:
+  ansible.builtin.copy:
     src: users/jay/{{ item.src }}
     dest: /home/jay/{{ item.dest }}
     owner: jay
-    group: jay
+    ansible.builtin.group: jay
     mode: 0600
   with_items:
     - { src: 'asunder', dest: '.asunder' }
@@ -67,9 +67,9 @@
 
 - name: users | jay | copy profile image
   tags: dotfiles,dotfiles-jay
-  copy:
+  ansible.builtin.copy:
     src: users/jay/profile_image.png
     dest: /var/lib/AccountsService/icons/jay.png
     owner: root
-    group: root
+    ansible.builtin.group: root
     mode: 0644


### PR DESCRIPTION
Instead of using eg `copy`, use `ansible.builtin.copy` to avoid possible clashes in names.

I went through all of the Ansible YAML files and replaced the short names. This is the result of running the following shell script:

```sh
find . -type f -name "*.yml" -exec perl -pi -e 's, (pacman|timezone|locale_gen|dconf|flatpak|snap|flatpak_remote):, community.general.$1:,' '{}' '+'

find . -type f -name "*.yml" -exec perl -pi -e 's, (file|apt|service|pip|lineinfile|copy|apt_repository|apt|cron|command|template|group|user|git|import_tasks|apt_key|get_url|unarchive|stat|blockinfile|debconf|include_tasks|include_vars|package|replace):, ansible.builtin.$1:,' '{}' '+'
```